### PR TITLE
Add consumer3.js and producer3.js using protobuf

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ declare a new connection to your local kafka broker, use the following address
 ```sh
 kafka:29092
 ```
+
+- Open additional terminals and start the protobuf-based producer and consumer
+```sh
+node producer3.js
+node consumer3.js
+```

--- a/consumer3.js
+++ b/consumer3.js
@@ -1,0 +1,65 @@
+const clientId = 'example-consumer-3';
+const clientGroupId = 'test-group-3';
+const sharedTopic = 'test-topic';
+const fromBeginning = true;
+
+const { Kafka } = require('kafkajs');
+const protobuf = require('protobufjs');
+const readline = require('readline');
+const fs = require('fs');
+
+const kafka = new Kafka({
+    brokers: ['localhost:9092'],
+    clientId: clientId,
+});
+
+const consumer = kafka.consumer({ groupId: clientGroupId });
+
+// Set up readline interface
+readline.emitKeypressEvents(process.stdin);
+process.stdin.setRawMode(true);
+
+let MessageProto;
+
+protobuf.load("message.proto", (err, root) => {
+    if (err) throw err;
+    MessageProto = root.lookupType("Message");
+});
+
+async function run() {
+    // Connect the consumer
+    await consumer.connect();
+
+    // Subscribe to the topic
+    await consumer.subscribe({ topic: sharedTopic, fromBeginning: fromBeginning });
+
+    console.log('Consumer started. Press any key to exit.');
+
+    // Run the consumer and print messages to console
+    await consumer.run({
+        eachMessage: async ({ topic, partition, message }) => {
+            const decodedMessage = MessageProto.decode(message.value);
+            console.log({
+                topic,
+                partition,
+                offset: message.offset,
+                value: decodedMessage,
+            });
+        },
+    });
+
+    // Listen for keypress event
+    process.stdin.on('keypress', async () => {
+        await shutdown();
+    });
+}
+
+async function shutdown() {
+    console.log('Shutting down...');
+    await consumer.disconnect();
+    process.exit(0);
+}
+
+run().catch(console.error);
+
+process.on('SIGINT', shutdown);

--- a/consumer3.js
+++ b/consumer3.js
@@ -38,13 +38,17 @@ async function run() {
     // Run the consumer and print messages to console
     await consumer.run({
         eachMessage: async ({ topic, partition, message }) => {
-            const decodedMessage = MessageProto.decode(message.value);
-            console.log({
-                topic,
-                partition,
-                offset: message.offset,
-                value: decodedMessage,
-            });
+            if (message.value.length > 0) {
+                const decodedMessage = MessageProto.decode(message.value);
+                console.log({
+                    topic,
+                    partition,
+                    offset: message.offset,
+                    value: decodedMessage,
+                });
+            } else {
+                console.error('Received empty message');
+            }
         },
     });
 

--- a/message.proto
+++ b/message.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message Message {
+  string content = 1;
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "ip": "^1.1.5",
     "kafkajs": "^1.12.0",
-    "readline": "^1.3.0"
+    "readline": "^1.3.0",
+    "protobufjs": "^6.11.2"
   }
 }

--- a/producer3.js
+++ b/producer3.js
@@ -1,0 +1,60 @@
+const clientId = 'example-producer-3';
+const sharedTopic = 'test-topic';
+
+const { Kafka } = require('kafkajs');
+const protobuf = require('protobufjs');
+const readline = require('readline');
+const fs = require('fs');
+
+const kafka = new Kafka({
+    brokers: ['localhost:9092'],
+    clientId: clientId
+});
+
+const producer = kafka.producer();
+
+// Create readline interface
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+let MessageProto;
+
+protobuf.load("message.proto", (err, root) => {
+    if (err) throw err;
+    MessageProto = root.lookupType("Message");
+});
+
+async function run() {
+  // Connect the producer
+  await producer.connect();
+
+  console.log('Connected to Kafka. Enter messages (press Ctrl+C to exit):');
+
+  rl.on('line', async (input) => {
+    try {
+      // Encode the message using protobuf
+      const message = MessageProto.create({ content: input });
+      const buffer = MessageProto.encode(message).finish();
+
+      // Send encoded message to Kafka
+      await producer.send({
+        topic: sharedTopic,
+        messages: [{ value: buffer }],
+      });
+      console.log('Message sent successfully');
+    } catch (error) {
+      console.error('Error sending message:', error);
+    }
+  });
+}
+
+run().catch(console.error);
+
+// Handle graceful shutdown
+process.on('SIGINT', async () => {
+  await producer.disconnect();
+  rl.close();
+  process.exit(0);
+});


### PR DESCRIPTION
Add new consumer3.js and producer3.js files using protobuf for Kafka messages.

* **consumer3.js**
  - Import `protobufjs` and `kafkajs`.
  - Load the protobuf schema from a `.proto` file.
  - Decode the protobuf message in `eachMessage` function.
  - Log the decoded message to the console.

* **producer3.js**
  - Import `protobufjs` and `kafkajs`.
  - Load the protobuf schema from a `.proto` file.
  - Encode the message using protobuf before sending.
  - Send the encoded message to Kafka.

* **package.json**
  - Add `protobufjs` as a dependency.

* **README.md**
  - Add instructions for running `consumer3.js` and `producer3.js`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/israelio/kafkajs-kadeck-example/pull/1?shareId=6eb9d8fe-d010-4611-b705-0000ccd77b32).